### PR TITLE
Fix service checks with empty tag hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+2.0.2/ 2016.09.21
+=================
+
+### Changes
+
+* [BUGFIX] Don't produce malformed packets when passing an empty hash to `service_check`,
+  [stripe/dogstatsd#2][] [@tummychow][]
+
 2.0.1/ 2016.02.25
 =================
 

--- a/lib/dogstatsd.rb
+++ b/lib/dogstatsd.rb
@@ -69,7 +69,7 @@ class DogStatsd
 
   # Return the current version of the library.
   def self.VERSION
-    "2.0.1"
+    "2.0.2"
   end
 
   # @param [String] host your statsd host
@@ -263,8 +263,10 @@ class DogStatsd
       if opts[name_key[0].to_sym]
         if name_key[0] == 'tags'
           tags = opts[:tags].map {|tag| remove_pipes(tag) }
-          tags = "#{tags.join(",")}" unless tags.empty?
-          sc_string << "|##{tags}"
+          unless tags.empty?
+            tags = "#{tags.join(",")}"
+            sc_string << "|##{tags}"
+          end
         elsif name_key[0] == 'message'
           message = remove_pipes(opts[:message])
           escaped_message = escape_service_check_message(message)

--- a/spec/dogstatsd_spec.rb
+++ b/spec/dogstatsd_spec.rb
@@ -547,6 +547,11 @@ describe DogStatsd do
         @statsd.socket.recv.must_equal ["_sc|#{name}|#{status}|##{tags_joined}"]
       end
 
+      it "With no tags" do
+        @statsd.service_check(name, status, :tags => {})
+        @statsd.socket.recv.must_equal ["_sc|#{name}|#{status}"]
+      end
+
       it "With hostname, message, and tags" do
         @statsd.service_check(name, status, :message => 'testing | m: \n', :hostname => 'hostname_test',
                               :tags => tags)


### PR DESCRIPTION
I stumbled upon service check packets looking like this:

`_sc|foo|0|#[]|m:bar`

and decided to fix them. Will submit a separate PR for upstream, since we've diverged.
